### PR TITLE
Fix silvia_posts_query_404_args filter in template-tags.php

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -491,7 +491,7 @@ function silvia_posts_query_404() {
 	);
 
 	// Allow dev to filter the arguments
-	$posts = apply_filters( 'silvia_posts_query_404_args', $args );
+	$args = apply_filters( 'silvia_posts_query_404_args', $args );
 
 	// Our hero!
 	$posts = new WP_Query( $args );


### PR DESCRIPTION
There is a small error which elimintates the usefullness of your filter for devs. Altough redeclaring your function also worked, it still would be nice to see a fix. Thanks for your awesome work!